### PR TITLE
fixed parse_object's comment wrong when after key is not colon

### DIFF
--- a/pj/parser.py
+++ b/pj/parser.py
@@ -37,7 +37,8 @@ def parse_object(tokens):
         else:
             raise Exception('Expected string key, got: {}'.format(json_key))
 
-        if tokens[0] != JSON_COLON:
+        t = tokens[0]
+        if t != JSON_COLON:
             raise Exception('Expected colon after key in object, got: {}'.format(t))
 
         json_value, tokens = parse(tokens[1:])

--- a/tests/test_pj.py
+++ b/tests/test_pj.py
@@ -34,6 +34,13 @@ class TestStringMethods(unittest.TestCase):
     def test_basic_whitespace(self):
         self.assertEqual(pj.from_string('{ "foo" : [1, 2, "three"] }'), {"foo": [1, 2, "three"]})
 
+    def test_afert_colon_not_key(self):
+        try:
+            pj.from_string('{ "foo" 1 [1, 2, "three"] }')
+        except Exception as e:
+            self.assertEqual(str(e), "Expected colon after key in object, got: 1")
+        else:
+            self.assertEqual(true, false)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The comment is wrong when after key is not colon